### PR TITLE
Fix indentation and spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ vue-quill-editor的增强模块，
 npm install quill-image-extend-module --save-dev
 ```
 ## use
-```ecmascript 6
-  import {quillEditor, Quill} from 'vue-quill-editor'
-  import {container, ImageExtend, QuillWatch} from 'quill-image-extend-module'
+```js
+import {quillEditor, Quill} from 'vue-quill-editor'
+import {container, ImageExtend, QuillWatch} from 'quill-image-extend-module'
 
-  Quill.register('modules/ImageExtend', ImageExtend)
+Quill.register('modules/ImageExtend', ImageExtend)
 ```
 ## example
-```ecmascript 6
+```html
 <template>
   <div class="quill-wrap">
     <quill-editor
@@ -54,7 +54,7 @@ npm install quill-image-extend-module --save-dev
       return {
        content: '',
         // 富文本框参数设置
-        editorOption: {  
+        editorOption: {
           modules: {
             ImageExtend: {
               loading: true,
@@ -81,42 +81,42 @@ npm install quill-image-extend-module --save-dev
 
 ```
 ## quill-image-extend-module 的所有可配置项
-```ecmascript 6
- editorOption: {
-                     modules: {
-                         ImageExtend: {  // 如果不作设置，即{}  则依然开启复制粘贴功能且以base64插入 
-                             name: 'img',  // 图片参数名
-                             size: 3,  // 可选参数 图片大小，单位为M，1M = 1024kb
-                             action: updateUrl,  // 服务器地址, 如果action为空，则采用base64插入图片
-                             // response 为一个函数用来获取服务器返回的具体图片地址
-                             // 例如服务器返回{code: 200; data:{ url: 'baidu.com'}}
-                             // 则 return res.data.url
-                             response: (res) => {
-                                 return res.info
-                             },
-                             headers: (xhr) => {
-                             // xhr.setRequestHeader('myHeader','myValue')
-                             },  // 可选参数 设置请求头部
-                             sizeError: () => {},  // 图片超过大小的回调
-                             start: () => {},  // 可选参数 自定义开始上传触发事件
-                             end: () => {},  // 可选参数 自定义上传结束触发的事件，无论成功或者失败
-                             error: () => {},  // 可选参数 上传失败触发的事件
-                             success: () => {},  // 可选参数  上传成功触发的事件
-                             change: (xhr, formData) => {
-                             // xhr.setRequestHeader('myHeader','myValue')
-                             // formData.append('token', 'myToken')
-                             } // 可选参数 每次选择图片触发，也可用来设置头部，但比headers多了一个参数，可设置formData
-                         },
-                         toolbar: {  // 如果不上传图片到服务器，此处不必配置
-                             container: container,  // container为工具栏，此次引入了全部工具栏，也可自行配置
-                             handlers: {
-                                 'image': function () {  // 劫持原来的图片点击按钮事件
-                                     QuillWatch.emit(this.quill.id)
-                                 }
-                             }
-                         }
-                     }
-                 }
+```js
+editorOption: {
+  modules: {
+    ImageExtend: {  // 如果不作设置，即{}  则依然开启复制粘贴功能且以base64插入
+      name: 'img',  // 图片参数名
+      size: 3,  // 可选参数 图片大小，单位为M，1M = 1024kb
+      action: updateUrl,  // 服务器地址, 如果action为空，则采用base64插入图片
+      // response 为一个函数用来获取服务器返回的具体图片地址
+      // 例如服务器返回{code: 200; data:{ url: 'baidu.com'}}
+      // 则 return res.data.url
+      response: (res) => {
+        return res.info
+      },
+      headers: (xhr) => {
+      // xhr.setRequestHeader('myHeader','myValue')
+      },  // 可选参数 设置请求头部
+      sizeError: () => {},  // 图片超过大小的回调
+      start: () => {},  // 可选参数 自定义开始上传触发事件
+      end: () => {},  // 可选参数 自定义上传结束触发的事件，无论成功或者失败
+      error: () => {},  // 可选参数 上传失败触发的事件
+      success: () => {},  // 可选参数  上传成功触发的事件
+      change: (xhr, formData) => {
+      // xhr.setRequestHeader('myHeader','myValue')
+      // formData.append('token', 'myToken')
+      } // 可选参数 每次选择图片触发，也可用来设置头部，但比headers多了一个参数，可设置formData
+    },
+    toolbar: {  // 如果不上传图片到服务器，此处不必配置
+      container: container,  // container为工具栏，此次引入了全部工具栏，也可自行配置
+      handlers: {
+        image: function () {  // 劫持原来的图片点击按钮事件
+          QuillWatch.emit(this.quill.id)
+        }
+      }
+    }
+  }
+}
 ```
 ### 注意事项 （matters need attention）
 由于不同的用户的服务器返回的数据格式不尽相同
@@ -148,7 +148,7 @@ result: {
 ```
 
 ## 与其他模块一起使用（以resize-module为例子）
-```ecmascript 6
+```html
 <template>
   <div class="quill-wrap">
     <quill-editor
@@ -160,38 +160,37 @@ result: {
   </div>
 </template>
 <script>
-  import {quillEditor, Quill} from 'vue-quill-editor'
-  import {container, ImageExtend, QuillWatch} from 'quill-image-extend-module'
-  import ImageResize from 'quill-image-resize-module'
+import {quillEditor, Quill} from 'vue-quill-editor'
+import {container, ImageExtend, QuillWatch} from 'quill-image-extend-module'
+import ImageResize from 'quill-image-resize-module'
 
-  Quill.register('modules/ImageExtend', ImageExtend)
-  // use resize module
-  Quill.register('modules/ImageResize', ImageResize)
-  export default {
-    components: {quillEditor},
-    data() {
-      return {
-        content: '',
-        // 富文本框参数设置
-        editorOption: {
-          modules: {
-            ImageResize: {},
-            ImageExtend: {
-              name: 'img',
-              size: 2,  // 单位为M, 1M = 1024KB
-              action: updateUrl,
-              headers: (xhr) => {
-              },
-              response: (res) => {
-                return res.info
-              }
+Quill.register('modules/ImageExtend', ImageExtend)
+// use resize module
+Quill.register('modules/ImageResize', ImageResize)
+export default {
+  components: {quillEditor},
+  data() {
+    return {
+      content: '',
+      // 富文本框参数设置
+      editorOption: {
+        modules: {
+          ImageResize: {},
+          ImageExtend: {
+            name: 'img',
+            size: 2,  // 单位为M, 1M = 1024KB
+            action: updateUrl,
+            headers: (xhr) => {
             },
-            toolbar: {
-              container: container,
-              handlers: {
-                'image': function () {
-                  QuillWatch.emit(this.quill.id)
-                }
+            response: (res) => {
+              return res.info
+            }
+          },
+          toolbar: {
+            container: container,
+            handlers: {
+              'image': function () {
+                QuillWatch.emit(this.quill.id)
               }
             }
           }
@@ -199,6 +198,7 @@ result: {
       }
     }
   }
+}
 </script>
 
 ```
@@ -207,14 +207,3 @@ result: {
 
 
 ## (如果觉得还不错，请右上角点击下星星，此致敬礼)
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This PR fix
- spacing and indentation error in the README
- change code block syntax from `ecmascript 6` to `html` and `js` respectively so that syntax highlighting on github will work correctly.